### PR TITLE
Resolve incompatibility between standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.1
+### Fixed
+- Resolve incompatibility with `PSR12.ControlStructures.ControlStructureSpacing` (from the `Youwe` standard) and `PSR2.ControlStructures.ControlStructureSpacing` (from the `Magento2` standard).
+  For details, see https://github.com/YouweGit/coding-standard-magento2/issues/6.
+
 ## 2.1.0
 ### Changed
 - Youwe ruleset will not check .phtml files anymore and only uses the Magento2 coding standards to check files on `phpcs`.
@@ -13,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Composer package youwe/coding-standard which is now included in the Youwe coding standards for Magento 2.
 - Comments for why the ruleset was added.
 - Coding standards for phtml templates.
-- Package [magento/magento-coding-standard](https://github.com/magento/magento-coding-standard) as a requirement. 
+- Package [magento/magento-coding-standard](https://github.com/magento/magento-coding-standard) as a requirement.
   The version v25 is used as a base. If not compatible please update the `phpcs.xml` in project root.
 
 ### Removed

--- a/src/YouweMagento2/ruleset.xml
+++ b/src/YouweMagento2/ruleset.xml
@@ -38,6 +38,10 @@
         Also most class properties are self-explanatory.
         -->
         <exclude name="Magento2.Commenting.ClassPropertyPHPDocFormatting" />
+
+        <!-- While we wait for https://github.com/magento/magento-coding-standard/pull/416 to be merged -->
+        <!-- See also https://github.com/YouweGit/coding-standard-magento2/issues/6 -->
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing" />
     </rule>
 
     <rule ref="Squiz.WhiteSpace.MemberVarSpacing" >


### PR DESCRIPTION
This will fix #6 while we wait for the `Magento2` standard to adopt PSR-12.