### PR TITLE
Also exclude HTML files from Youwe coding standard ruleset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.3
+### Fixed
+- Youwe ruleset will not check .html files any more. See also version 2.1.0.
+
 ## 2.1.2
 ### Changed
 - Allow use of stable version of `dealerdirect/phpcodesniffer-composer-installer`

--- a/src/YouweMagento2/ruleset.xml
+++ b/src/YouweMagento2/ruleset.xml
@@ -26,7 +26,7 @@
         <exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing" />
         <!-- Magento 2 still does not strict type arguments of functions. This is why this rule is excluded. -->
         <exclude name="Squiz.Commenting.FunctionComment.TypeHintMissing" />
-        <exclude-pattern>*.phtml</exclude-pattern>
+        <exclude-pattern>*.p?html</exclude-pattern>
     </rule>
 
     <!-- Import most rules from official Magento2 coding standard -->


### PR DESCRIPTION
This is a follow-up to #5, where `*.phtml` files were excluded from the rules in the `Youwe` coding standard (which is designed for `*.php` files only). The `Magento2` coding standard treats `*.html` files as PHP: https://github.com/magento/magento-coding-standard/blob/aec6744c0d1ad05f836b653e43dde756f23a389d/Magento2/ruleset.xml#L6

We're getting some noise from `Generic.PHP.DisallowAlternativePHPTags.MaybeASPOpenTagFound` and `Generic.PHP.DisallowAlternativePHPTags.MaybeASPShortOpenTag` in HTML files using Knockout in Magento projects. This rule is included via [`Youwe`](https://github.com/YouweGit/coding-standard-magento2/blob/efc95a80fc6f59ea16ab846f1fcbc989f886ac42/src/YouweMagento2/ruleset.xml#L16) -> [`GlobalCommon`](https://github.com/YouweGit/coding-standard/blob/cb1f784dadd54deb80d2fda45959f5c8719d5d40/src/Youwe/ruleset.xml#L11) -> [`PSR12`](https://github.com/YouweGit/coding-standard/blob/cb1f784dadd54deb80d2fda45959f5c8719d5d40/src/GlobalCommon/ruleset.xml#L16) -> [`PSR1`](https://github.com/squizlabs/PHP_CodeSniffer/blob/ed8e00df0a83aa96acf703f8c2979ff33341f879/src/Standards/PSR12/ruleset.xml#L11) -> [`Generic.PHP.DisallowAlternativePHPTags`](https://github.com/squizlabs/PHP_CodeSniffer/blob/ed8e00df0a83aa96acf703f8c2979ff33341f879/src/Standards/PSR1/ruleset.xml#L10).