### PR TITLE
Make exclusion list more specific for Magento template files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.0
+## Changed
+- Apply more rules to .html and .phtml files. In previous updates (see pull requests [#5] and [#10]), we excluded these files very widely; this change makes the exclusion more specific and intentional.
+
+[#5]: https://github.com/YouweGit/coding-standard-magento2/pull/5
+[#10]: https://github.com/YouweGit/coding-standard-magento2/pull/10
+
 ## 2.1.3
 ### Fixed
 - Youwe ruleset will not check .html files any more. See also version 2.1.0.

--- a/src/YouweMagento2/ruleset.xml
+++ b/src/YouweMagento2/ruleset.xml
@@ -58,18 +58,19 @@
         template files. We can't use a single <exclude-pattern> directive in the
         <rule ref="Youwe"> block above, as that would also apply to any sniffs
         which are in both standards.
+        And XML files are excluded here too.
     -->
-    <rule ref="Generic.Commenting.DocComment"><exclude-pattern>*.p?html</exclude-pattern></rule>
-    <rule ref="Generic.PHP.DisallowAlternativePHPTags"><exclude-pattern>*.p?html</exclude-pattern></rule>
-    <rule ref="PSR12.ControlStructures.BooleanOperatorPlacement"><exclude-pattern>*.p?html</exclude-pattern></rule>
-    <rule ref="PSR12.ControlStructures.ControlStructureSpacing"><exclude-pattern>*.p?html</exclude-pattern></rule>
-    <rule ref="PSR12.Files.DeclareStatement"><exclude-pattern>*.p?html</exclude-pattern></rule>
-    <rule ref="PSR12.Files.FileHeader"><exclude-pattern>*.p?html</exclude-pattern></rule>
-    <rule ref="PSR12.Traits.UseDeclaration"><exclude-pattern>*.p?html</exclude-pattern></rule>
-    <rule ref="Squiz.Arrays.ArrayDeclaration"><exclude-pattern>*.p?html</exclude-pattern></rule>
-    <rule ref="Squiz.Commenting.FunctionComment"><exclude-pattern>*.p?html</exclude-pattern></rule>
-    <rule ref="Squiz.Commenting.FunctionCommentThrowTag"><exclude-pattern>*.p?html</exclude-pattern></rule>
-    <rule ref="Squiz.Commenting.VariableComment"><exclude-pattern>*.p?html</exclude-pattern></rule>
-    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"><exclude-pattern>*.p?html</exclude-pattern></rule>
-    <rule ref="Squiz.WhiteSpace.FunctionSpacing"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="Generic.Commenting.DocComment"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Generic.PHP.DisallowAlternativePHPTags"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR12.ControlStructures.BooleanOperatorPlacement"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR12.ControlStructures.ControlStructureSpacing"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR12.Files.DeclareStatement"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR12.Files.FileHeader"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR12.Traits.UseDeclaration"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Squiz.Arrays.ArrayDeclaration"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Squiz.Commenting.FunctionComment"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Squiz.Commenting.FunctionCommentThrowTag"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Squiz.Commenting.VariableComment"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Squiz.WhiteSpace.FunctionSpacing"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
 </ruleset>

--- a/src/YouweMagento2/ruleset.xml
+++ b/src/YouweMagento2/ruleset.xml
@@ -26,7 +26,6 @@
         <exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing" />
         <!-- Magento 2 still does not strict type arguments of functions. This is why this rule is excluded. -->
         <exclude name="Squiz.Commenting.FunctionComment.TypeHintMissing" />
-        <exclude-pattern>*.p?html</exclude-pattern>
     </rule>
 
     <!-- Import most rules from official Magento2 coding standard -->
@@ -49,4 +48,28 @@
             <property name="spacingBeforeFirst" value="0"/>
         </properties>
     </rule>
+
+    <!--
+        These sniffs are in the Youwe standard, but should not apply to Magento2
+        templates.
+        Because the Magento2 standard tells PHP_CodeSniffer to treat all *.html
+        and *.phtml files as PHP files, we need to add <exclude-pattern>
+        directives to specifically stop these sniffs from applying to Magento
+        template files. We can't use a single <exclude-pattern> directive in the
+        <rule ref="Youwe"> block above, as that would also apply to any sniffs
+        which are in both standards.
+    -->
+    <rule ref="Generic.Commenting.DocComment"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="Generic.PHP.DisallowAlternativePHPTags"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="PSR12.ControlStructures.BooleanOperatorPlacement"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="PSR12.ControlStructures.ControlStructureSpacing"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="PSR12.Files.DeclareStatement"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="PSR12.Files.FileHeader"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="PSR12.Traits.UseDeclaration"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="Squiz.Arrays.ArrayDeclaration"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="Squiz.Commenting.FunctionComment"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="Squiz.Commenting.FunctionCommentThrowTag"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="Squiz.Commenting.VariableComment"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"><exclude-pattern>*.p?html</exclude-pattern></rule>
+    <rule ref="Squiz.WhiteSpace.FunctionSpacing"><exclude-pattern>*.p?html</exclude-pattern></rule>
 </ruleset>


### PR DESCRIPTION
When working with a website that we have inherited from another agency, I noticed that the `Generic.PHP.DisallowShortOpenTag` rule was applying to `*.php` files, but not to `*.phtml` files. After some investigation, I found that the `<exclude-pattern>` directive was applying too broadly. When a sniff is in both standards, this `<exclude-pattern>` rule meant that it would only apply to PHP files, not Magento2 template files.

I made a list of all overlapping sniffs (ie, those in both the `Youwe` and `Magento2` standards), and then included only those that made sense to *not* apply to Magento template files in the exclude list. To see the sniffs included in these standards, one can run `vendor/bin/phpcs -e --standard=Youwe` and `vendor/bin/phpcs -e --standard=Magento2`.

Some examples of a sniffs not marked for exclusion here are:
- `GlobalPhpUnit.Coverage.CoversTag` - we should not be defining any PHPUnit test classes/methods in template files, so this rule should never match anything anyway.
- `PSR12.Classes.OpeningBraceSpace` - no classes should be declared in template files, so this rule should never match anything anyway.
- `Squiz.WhiteSpace.CastSpacing` - cast syntax should be uniform in all files scanned, not just `.php` files.

This is a follow-up to #5 and #10.