### PR TITLE
Avoid breaking XML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.1
+### Fixed
+- Avoid breaking XML files by excluding `PSR12.Operators.OperatorSpacing` from running there.
+
 ## 2.2.0
-## Changed
+### Changed
 - Apply more rules to .html and .phtml files. In previous updates (see pull requests [#5] and [#10]), we excluded these files very widely; this change makes the exclusion more specific and intentional.
 
 [#5]: https://github.com/YouweGit/coding-standard-magento2/pull/5

--- a/src/YouweMagento2/ruleset.xml
+++ b/src/YouweMagento2/ruleset.xml
@@ -73,4 +73,6 @@
     <rule ref="Squiz.Commenting.VariableComment"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
     <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
     <rule ref="Squiz.WhiteSpace.FunctionSpacing"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <!-- Excluding this for the same reasons as above, but only for XML files -->
+    <rule ref="PSR12.Operators.OperatorSpacing"><exclude-pattern>*.xml$</exclude-pattern></rule>
 </ruleset>


### PR DESCRIPTION
Following on from https://github.com/YouweGit/coding-standard-magento2/pull/11, this pull request aims to avoid breaking XML files when short_open_tags is enabled (which is needed for some sniffs). It's not sensible to treat XML files as PHP code...