### PR TITLE
Fix to strict rules and exclude pattern uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.1
+## Fixed
+- Exclude pattern, the patterns did not include the dot of the extension allowing matching with the pathname (which for example in DDEV will match with `html` in `/var/www/html`)
+## Changed
+- Included more rules to exclude for (p)html and xml files. Indentation, line-length are very hard to fix consistently and prevents usage of component libraries (as for example with Hyvä)
+
 ## 2.2.0
 ## Changed
 - Apply more rules to .html and .phtml files. In previous updates (see pull requests [#5] and [#10]), we excluded these files very widely; this change makes the exclusion more specific and intentional.

--- a/src/YouweMagento2/ruleset.xml
+++ b/src/YouweMagento2/ruleset.xml
@@ -60,17 +60,28 @@
         which are in both standards.
         And XML files are excluded here too.
     -->
-    <rule ref="Generic.Commenting.DocComment"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
-    <rule ref="Generic.PHP.DisallowAlternativePHPTags"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
-    <rule ref="PSR12.ControlStructures.BooleanOperatorPlacement"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
-    <rule ref="PSR12.ControlStructures.ControlStructureSpacing"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
-    <rule ref="PSR12.Files.DeclareStatement"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
-    <rule ref="PSR12.Files.FileHeader"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
-    <rule ref="PSR12.Traits.UseDeclaration"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
-    <rule ref="Squiz.Arrays.ArrayDeclaration"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
-    <rule ref="Squiz.Commenting.FunctionComment"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
-    <rule ref="Squiz.Commenting.FunctionCommentThrowTag"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
-    <rule ref="Squiz.Commenting.VariableComment"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
-    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
-    <rule ref="Squiz.WhiteSpace.FunctionSpacing"><exclude-pattern>*.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Generic.Commenting.DocComment"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Generic.ControlStructures.InlineControlStructure.NotAllowed"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Generic.Files.LineLength.TooLong"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Generic.Formatting.DisallowMultipleStatements.SameLine"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Generic.PHP.DisallowAlternativePHPTags"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR12.ControlStructures.BooleanOperatorPlacement"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR12.ControlStructures.ControlStructureSpacing"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR12.Files.DeclareStatement"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR12.Files.FileHeader"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR12.Traits.UseDeclaration"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR2.Methods.FunctionCallSignature.CloseBracketLine"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR2.Methods.FunctionCallSignature.ContentAfterOpenBracket"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR2.Methods.FunctionCallSignature.Indent"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PSR2.Methods.FunctionCallSignature.MultipleArguments"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Squiz.Arrays.ArrayDeclaration"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Squiz.Commenting.FunctionComment"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Squiz.Commenting.FunctionCommentThrowTag"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Squiz.Commenting.VariableComment"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
+    <rule ref="Squiz.WhiteSpace.FunctionSpacing"><exclude-pattern>\.(x|p?ht)ml$</exclude-pattern></rule>
 </ruleset>


### PR DESCRIPTION
* Fix Exclude pattern, the patterns did not include the dot of the extension allowing matching with the pathname (which for example in DDEV will match with `html` in `/var/www/html`)

* Included more rules to exclude for (p)html and xml files. Indentation, line-length are very hard to fix consistently and prevents usage of component libraries (as for example with Hyvä)